### PR TITLE
fix failure of test_crypto due to missing "mock" module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ test_requirements = [
     'python-keyczar',
     'fs>=0.5',
     'pycrypto',
+    'mock',
 ]
 "dependencies for running tests"
 
@@ -33,6 +34,10 @@ if sys.version_info >= (3, 0):
     # keyczar doesn't currently install on Python 3. Omit it also.
     # http://code.google.com/p/keyczar/issues/detail?id=125
     test_requirements.remove('python-keyczar')
+
+    # mock is included in Python3 unittest
+    # https://pypi.python.org/pypi/mock
+    test_requirements.remove('mock')
 
 setup_params = dict(
     name='keyrings.alt',

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,5 +1,8 @@
-import unittest
-import mock
+import sys, unittest
+if sys.version_info >= (3, 3):
+    from unittest import mock
+else:
+    import mock
 
 from .test_file import FileKeyringTests
 


### PR DESCRIPTION
Currently test relies on "mock" package (fails if not present)
For Python2: add it to test_requires
For Python3: use unittest.mock instead
