### PR TITLE
RFC: Crypted file store based on Fernet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,61 @@
+# Created by https://www.gitignore.io
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Editor backups
+*~

--- a/keyrings/alt/fernet.py
+++ b/keyrings/alt/fernet.py
@@ -1,0 +1,84 @@
+from __future__ import with_statement
+
+import os
+import getpass
+import base64
+import sys
+import json
+
+from keyring.py27compat import configparser
+
+from keyring.util import properties
+from keyring.util.escape import escape as escape_for_ini
+
+from keyrings.alt.file import EncryptedKeyring
+
+class FernetEncryption(object):
+    """
+    Cryptography.io-backed Encryption support
+    """
+    scheme = 'Cryptography [PBKDF2HMAC] Fernet'
+    version = '1.0'
+    file_version = None
+
+    def _create_cipher(self, password, salt):
+        """
+        Create the cipher object to encrypt or decrypt a payload.
+        """
+        from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+        from cryptography.hazmat.backends import default_backend
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.fernet import Fernet
+
+        kdf = PBKDF2HMAC(algorithm=hashes.SHA256(),
+                         length=32, salt=salt, iterations=100000,
+                         backend=default_backend())
+        key = base64.urlsafe_b64encode(kdf.derive(password.encode()))
+        return Fernet(key)
+
+
+class FernetKeyring(FernetEncryption, EncryptedKeyring):
+    """
+    Cryptography.io-based File Keyring with Scrypt and Fernet
+    """
+    # specify keyring file
+    filename = 'fernet_pass.cfg'
+    pw_prefix = 'pw:'.encode()
+
+    @properties.ClassProperty
+    @classmethod
+    def priority(self):
+        """
+        Applicable for all platforms, where the schemes, that are integrated
+        with your environment, does not fit.
+        """
+        try:
+            __import__('cryptography.fernet')
+            __import__('cryptography.hazmat.primitives.hashes')
+            __import__('cryptography.hazmat.primitives.kdf.pbkdf2')
+        except ImportError:
+            raise RuntimeError("cryptography package required")
+        if not json:
+            raise RuntimeError("JSON implementation such as simplejson "
+                "required.")
+        return 2.5
+
+    def encrypt(self, password):
+        salt = os.urandom(16)
+        cipher = self._create_cipher(self.keyring_key, salt)
+        password_encrypted = cipher.encrypt(self.pw_prefix + password)
+        # Serialize the salt and encrypted password in a secure format
+        data = dict(salt=salt, password_encrypted=password_encrypted)
+        for key in data:
+            data[key] = base64.encodestring(data[key]).decode()
+        return json.dumps(data).encode()
+
+    def decrypt(self, password_encrypted):
+        # unpack the encrypted payload
+        data = json.loads(password_encrypted.decode())
+        for key in data:
+            data[key] = base64.decodestring(data[key].encode())
+        cipher = self._create_cipher(self.keyring_key, data['salt'])
+        plaintext = cipher.decrypt(data['password_encrypted'])
+        assert plaintext.startswith(self.pw_prefix)
+        return plaintext[len(self.pw_prefix):]

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup_params = dict(
             'Gnome = keyrings.alt.Gnome',
             'Google = keyrings.alt.Google',
             'keyczar = keyrings.alt.keyczar',
+            'fernet = keyrings.alt.fernet',
             'multi = keyrings.alt.multi',
             'pyfs = keyrings.alt.pyfs',
             'Windows (alt) = keyrings.alt.Windows',

--- a/tests/test_fernet.py
+++ b/tests/test_fernet.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest import mock
+
+from .test_file import FileKeyringTests
+
+from keyrings.alt import fernet
+
+def is_cryptography_supported():
+    try:
+        __import__('cryptography.fernet')
+        __import__('cryptography.hazmat.primitives.hashes')
+        __import__('cryptography.hazmat.primitives.kdf.pbkdf2')
+    except ImportError:
+        return False
+    return True
+
+
+@unittest.skipUnless(is_cryptography_supported(),
+                     "Need cryptography package")
+class FernetFileKeyringTestCase(FileKeyringTests, unittest.TestCase):
+
+    def setUp(self):
+        super(self.__class__, self).setUp()
+        fake_getpass = mock.Mock(return_value='abcdef')
+        self.patcher = mock.patch('getpass.getpass', fake_getpass)
+        self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def init_keyring(self):
+        return fernet.FernetKeyring()

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -32,6 +32,12 @@ class FileKeyringTests(BackendBasicTests):
 
         self.assertEqual(password, self.keyring.decrypt(encrypted))
 
+    def test_scheme(self):
+        self.assertTrue(self.keyring.scheme is not None)
+
+    def test_version(self):
+        self.assertTrue(self.keyring.version is not None)
+
 
 class UncryptedFileKeyringTestCase(FileKeyringTests, unittest.TestCase):
 


### PR DESCRIPTION
Hi,
since there's some movement in cryptography lately, here's an attempt to implement a Fernet-based file store for python-keyring. [Fernet Spec](https://github.com/fernet/spec/blob/master/Spec.md).

For the same reason, I added properties for scheme and version to FileBacked in order to have a chance to implement a meaningful _migrate procedure later on. The idea is to also compare the (encryption) scheme on load, if it exists in the file backend. I think, that the minor code refactorings are worth it. 

Regarding cryptography in this package:
Well, it's a pain due to the crypto state for python in general. keyczar is officially in [weak](https://github.com/google/keyczar#keyczar) state, pycrypto is stalled [(pycryptodome](https://github.com/Legrandin/pycryptodome) might be a better alternative), and then there is [cryptography](https://github.com/pyca/cryptography), that is *maintained* at least.

Regarding my fernet implementation:
I would have loved to use Scrypt (at least..) as KDF, but my distribution doesn't support openssl 1.1.0, yet, which is what the cryptography is based on. I resorted to using PBKDF2HMAC, which is acceptable for now, but since the KDF is the weakest spot, given the hash power, that is available today *worldwide*, that issue needs addressing. 

At the moment, I'm struggling how I signal decryption exceptions to the upper layers. cryptography raises cryptography.fernet.InvalidToken for non matching passwords in decrypt. Give an advice, please.

I'm considering another crypto file format, that is based on [Argon2](https://github.com/P-H-C/phc-winner-argon2), but that is adding a pretty experimental codebase as dependency... Now, you hopefully see my intentions behind scheme and version.

Please, share your thoughts, thanks.

Cheers,
Pete