### PR TITLE
Fix exception name in pyfs

### DIFF
--- a/keyrings/alt/pyfs.py
+++ b/keyrings/alt/pyfs.py
@@ -103,7 +103,7 @@ class BasicKeyring(KeyringBackend):
                         self._pyfs = fs.remote.CacheFS(
                             self._pyfs, cache_timeout=self._cache_timeout)
                 open_file = self._pyfs.open(self._path, mode)
-        except fs.errors.ResourceNotFoundError:
+        except fs.errors.ResourceNotFound:
             if self._can_create:
                 segments = fs.opener.opener.split_segments(self.filename)
                 if segments:
@@ -140,7 +140,7 @@ class BasicKeyring(KeyringBackend):
                     self._pyfs = pyfs
                     self._path = url2
                     return pyfs.open(url2, mode)
-                except fs.errors.ResourceNotFoundError:
+                except fs.errors.ResourceNotFound:
                     if writeable:
                         raise
                     else:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,16 +1,7 @@
 pytest >= 2.8
-subprocess32; python_version=="2.6"
-backports.unittest_mock
+backports.unittest_mock; python_version=="2.7"
 keyring[test] >= 10.3.1
-
-fs>=0.5,<2
+fs>=2
 pycrypto
-
-# gdata doesn't currently install on Python 3
-# http://code.google.com/p/gdata-python-client/issues/detail?id=229
-gdata; python_version=="2.7"
-
-
-# keyczar doesn't currently install on Python 3.
-# http://code.google.com/p/keyczar/issues/detail?id=125
-python-keyczar; python_version=="2.7"
+gdata
+python-keyczar


### PR DESCRIPTION
Replaces `ResourceNotFoundError` by `ResourceNotFound`