### PR TITLE
file_base.py: Raise TypeError when passed password is bytes

### DIFF
--- a/keyrings/alt/file_base.py
+++ b/keyrings/alt/file_base.py
@@ -4,6 +4,7 @@ import os
 import abc
 import base64
 
+from six import string_types
 from six.moves import configparser
 
 from keyring.errors import PasswordDeleteError
@@ -126,6 +127,8 @@ class Keyring(FileBacked, KeyringBackend):
         if not username:
             # https://github.com/jaraco/keyrings.alt/issues/21
             raise ValueError("Username cannot be blank.")
+        if not isinstance(password, string_types):
+            raise TypeError("Password should be a unicode string, not bytes.")
         assoc = self._generate_assoc(service, username)
         # encrypt the password
         password_encrypted = self.encrypt(password.encode('utf-8'), assoc)


### PR DESCRIPTION
Fixes #23, refs jaraco/keyring#275.