### PR TITLE
pyfs: Check for pyfs 1.x, this code is incompatible with pyfs 2

### DIFF
--- a/keyrings/alt/file_base.py
+++ b/keyrings/alt/file_base.py
@@ -141,8 +141,8 @@ class Keyring(FileBacked, KeyringBackend):
     def _generate_assoc(self, service, username):
         """Generate tamper resistant bytestring of associated data
         """
-        return (escape_for_ini(service) + '\0' +
-                escape_for_ini(username)).encode()
+        return (escape_for_ini(service) + '\0'
+                + escape_for_ini(username)).encode()
 
     def _write_config_value(self, service, key, value):
         # ensure the file exists

--- a/keyrings/alt/pyfs.py
+++ b/keyrings/alt/pyfs.py
@@ -22,12 +22,12 @@ except ImportError:
 
 def has_pyfs():
     """
-    Does this environment have pyfs installed?
+    Does this environment have pyfs 1.x installed?
     Should return False even when Mercurial's Demand Import allowed import of
     fs.*.
     """
     with errors.ExceptionRaisedContext() as exc:
-        fs.__name__
+        fs.opener.opener
     return not bool(exc)
 
 

--- a/keyrings/alt/pyfs.py
+++ b/keyrings/alt/pyfs.py
@@ -91,8 +91,8 @@ class BasicKeyring(KeyringBackend):
             # NOTE: currently the MemOpener does not split off any filename
             #       which causes errors on close()
             #       so we add a dummy name and open it separately
-            if (self.filename.startswith('mem://') or
-                    self.filename.startswith('ram://')):
+            if (self.filename.startswith('mem://')
+                    or self.filename.startswith('ram://')):
                 open_file = fs.opener.fsopendir(self.filename).open('kr.cfg',
                                                                     mode)
             else:


### PR DESCRIPTION
With pyfs 2 this backend raises:

    AttributeError: module 'fs.errors' has no attribute 'ResourceNotFoundError'

and `setup.py` already requires `fs>=0.5,<2`.

Of course it would be better to port the code to pyfs 2, but that looks not trivial to me.