### PR TITLE
PlaintextKeyring is perfectly useless for storing any real secrets.  

### DIFF
--- a/keyrings/alt/file.py
+++ b/keyrings/alt/file.py
@@ -18,8 +18,8 @@ from keyrings.alt.file_base import (
 class PlaintextKeyring(Keyring):
     """Simple File Keyring with no encryption"""
 
-    priority = .5
-    "Applicable for all platforms, but not recommended"
+    priority = -0.5
+    "Applicable for all platforms, but utterly insecure"
 
     filename = 'keyring_pass.cfg'
     scheme = 'no encyption'


### PR DESCRIPTION
It should therefore be of lower priority than `keyring.backends.fail.Keyring`, because if there are no other keyrings, it's better to fail at that point.

There's no situation where a user should ever have their passwords written to plaintext files unless they explicitly choose to by writing a config file or by calling the `set_keyring()` function.

This is a fix for https://github.com/jaraco/keyring/issues/370