### PR TITLE
unit testing fixes and pyFileSystem 2 support

### DIFF
--- a/keyrings/alt/tests/test_pyfs.py
+++ b/keyrings/alt/tests/test_pyfs.py
@@ -3,6 +3,9 @@ from __future__ import unicode_literals
 import os
 import tempfile
 import textwrap
+import shutil
+import sys
+import errno
 
 import pytest
 
@@ -10,6 +13,18 @@ import keyring.backend
 from keyrings.alt import pyfs
 from keyring.testing.backend import BackendBasicTests
 from keyring.testing.util import random_string
+
+# support getting module version
+import pkg_resources
+
+# support parsing version string
+from packaging import version
+
+# check FS version
+try:
+    FS_VER = version.parse(pkg_resources.get_distribution("fs").version)
+except pkg_resources.DistributionNotFound:
+    raise ImportError
 
 
 class ReverseCrypter(keyring.backend.Crypter):
@@ -39,24 +54,38 @@ class PyFSBackend(BackendBasicTests):
 class TestUnencryptedMemoryPyfilesystemKeyringNoSubDir(PyFSBackend):
     """Test in memory with no encryption"""
 
-    keyring_filename = 'mem://unencrypted'
+    keyring_filename = 'mem://unencrypted/keyring.cfg'
+
+
+class TestUnencryptedMemoryPyfilesystemKeyringNoDir(PyFSBackend):
+    """Test in memory with no encryption"""
+
+    keyring_filename = 'mem://keyring.cfg'
 
 
 class TestUnencryptedMemoryPyfilesystemKeyringSubDir(PyFSBackend):
     """Test in memory with no encryption"""
 
-    keyring_filename = 'mem://some/sub/dir/unencrypted'
+    keyring_filename = 'mem://some/sub/dir/unencrypted/keyring.cfg'
 
 
 class TestUnencryptedLocalPyfilesystemKeyringNoSubDir(PyFSBackend):
     """Test using local temp files with no encryption"""
 
-    keyring_filename = '%s/keyring.cfg' % tempfile.mkdtemp()
+    keyring_root = tempfile.mkdtemp()
+    keyring_filename = '%s/keyring.cfg' % keyring_root
 
     def test_handles_preexisting_keyring(self):
-        from fs.opener import opener
+        if FS_VER < version.parse("2.0.0"):
+            from fs.opener import opener
 
-        fs, path = opener.parse(self.keyring_filename, writeable=True)
+            fs, path = opener.parse(self.keyring_filename, writeable=True)
+        else:
+            import fs.opener
+
+            fs, path = fs.opener.open(self.keyring_root, writeable=True, create=True)
+            path = os.path.basename(self.keyring_filename)
+
         keyring_file = fs.open(path, 'w')
         file_data = textwrap.dedent(
             """
@@ -69,20 +98,35 @@ class TestUnencryptedLocalPyfilesystemKeyringNoSubDir(PyFSBackend):
         pyf_keyring = pyfs.PlaintextKeyring(filename=self.keyring_filename)
         assert 'pwd1' == pyf_keyring.get_password('svc1', 'user1')
 
-    @pytest.fixture(autouse=True)
-    def remove_keyring_filename(self):
-        if os.path.exists(self.keyring_filename):
-            os.remove(self.keyring_filename)
+    @pytest.fixture(autouse=True, scope="class")
+    def _cleanup_for_fs(self):
+        yield
+        try:
+            shutil.rmtree(self.keyring_root)
+        except OSError:
+            e = sys.exc_info()[1]
+            if e.errno != errno.ENOENT:  # No such file or directory
+                raise
 
 
 class TestUnencryptedLocalPyfilesystemKeyringSubDir(PyFSBackend):
     """Test using local temp files with no encryption"""
 
-    keyring_dir = os.path.join(tempfile.mkdtemp(), 'more', 'sub', 'dirs')
+    keyring_root = tempfile.mkdtemp()
+    keyring_dir = os.path.join(keyring_root, 'more', 'sub', 'dirs')
     keyring_filename = os.path.join(keyring_dir, 'keyring.cfg')
 
-    def init_keyring(self):
+    @pytest.fixture(autouse=True, scope="class")
+    def _cleanup_for_fs(self):
+        yield
+        try:
+            shutil.rmtree(self.keyring_root)
+        except OSError:
+            e = sys.exc_info()[1]
+            if e.errno != errno.ENOENT:  # No such file or directory
+                raise
 
+    def init_keyring(self):
         if not os.path.exists(self.keyring_dir):
             os.makedirs(self.keyring_dir)
         return pyfs.PlaintextKeyring(filename=self.keyring_filename)
@@ -100,14 +144,41 @@ class TestEncryptedMemoryPyfilesystemKeyring(PyFSBackend):
 class TestEncryptedLocalPyfilesystemKeyringNoSubDir(PyFSBackend):
     """Test using local temp files with encryption"""
 
+    keyring_root = tempfile.mkdtemp()
+    keyring_filename = '%s/keyring.cfg' % keyring_root
+
     def init_keyring(self):
-        return pyfs.EncryptedKeyring(ReverseCrypter(), filename='temp://keyring.cfg')
+        return pyfs.EncryptedKeyring(ReverseCrypter(), filename=self.keyring_filename)
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _cleanup_for_fs(self):
+        yield
+        try:
+            shutil.rmtree(self.keyring_root)
+        except OSError:
+            e = sys.exc_info()[1]
+            if e.errno != errno.ENOENT:  # No such file or directory
+                raise
 
 
 class TestEncryptedLocalPyfilesystemKeyringSubDir(PyFSBackend):
     """Test using local temp files with encryption"""
 
+    keyring_root = tempfile.mkdtemp()
+    keyring_dir = os.path.join(keyring_root, 'more', 'sub', 'dirs')
+    keyring_filename = os.path.join(keyring_dir, 'keyring.cfg')
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _cleanup_for_fs(self):
+        yield
+        try:
+            shutil.rmtree(self.keyring_root)
+        except OSError:
+            e = sys.exc_info()[1]
+            if e.errno != errno.ENOENT:  # No such file or directory
+                raise
+
     def init_keyring(self):
-        return pyfs.EncryptedKeyring(
-            ReverseCrypter(), filename='temp://a/sub/dir/hierarchy/keyring.cfg'
-        )
+        if not os.path.exists(self.keyring_dir):
+            os.makedirs(self.keyring_dir)
+        return pyfs.EncryptedKeyring(ReverseCrypter(), filename=self.keyring_filename)

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ testing =
 	backports.unittest_mock
 	keyring >= 20
 
-	fs>=0.5,<2
+	fs>=0.5
 	pycryptodome
 
 	# gdata doesn't currently install on Python 3


### PR DESCRIPTION
Added support for pyFileSystem 2 in keyrings.alt  as my project requires both pyFS 2 and keyrings.alt.

Also fixed keyrings.alt unit tests, a lot of which were not run because they did not subclass unittest.TestCase nor followed pytest class naming conventions.

In my fork, I also created a branch (py27_pyfs2) off tags/v3.2.0 with similar changes but for python 2.7.   This is to support my users who may be staying with python 2.