### PR TITLE
Migrate from pycryptodome to pycryptodomex

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v4.0.0
+======
+
+#41: Instead of PyCrypto or PyCryptodome, the encrypting backend
+now relies on PyCryptodomex.
+
 v3.5.2
 ======
 

--- a/keyrings/alt/file.py
+++ b/keyrings/alt/file.py
@@ -33,7 +33,7 @@ class PlaintextKeyring(Keyring):
 
 class Encrypted(object):
     """
-    PyCrypto-backed Encryption support
+    PyCryptodome-backed Encryption support
     """
 
     scheme = '[PBKDF2] AES256.CFB'
@@ -44,8 +44,8 @@ class Encrypted(object):
         """
         Create the cipher object to encrypt or decrypt a payload.
         """
-        from Crypto.Protocol.KDF import PBKDF2
-        from Crypto.Cipher import AES
+        from Cryptodome.Protocol.KDF import PBKDF2
+        from Cryptodome.Cipher import AES
 
         pw = PBKDF2(password, salt, dkLen=self.block_size)
         return AES.new(pw[: self.block_size], AES.MODE_CFB, IV)
@@ -65,7 +65,7 @@ class Encrypted(object):
 
 
 class EncryptedKeyring(Encrypted, Keyring):
-    """PyCrypto File Keyring"""
+    """PyCryptodome File Keyring"""
 
     filename = 'crypted_pass.cfg'
     pw_prefix = 'pw:'.encode()
@@ -75,11 +75,11 @@ class EncryptedKeyring(Encrypted, Keyring):
     def priority(self):
         "Applicable for all platforms, but not recommended."
         try:
-            __import__('Crypto.Cipher.AES')
-            __import__('Crypto.Protocol.KDF')
-            __import__('Crypto.Random')
+            __import__('Cryptodome.Cipher.AES')
+            __import__('Cryptodome.Protocol.KDF')
+            __import__('Cryptodome.Random')
         except ImportError:  # pragma: no cover
-            raise RuntimeError("PyCrypto required")
+            raise RuntimeError("pycryptodomex required")
         if not json:  # pragma: no cover
             raise RuntimeError("JSON implementation such as simplejson required.")
         return 0.6
@@ -190,10 +190,10 @@ class EncryptedKeyring(Encrypted, Keyring):
 
     def encrypt(self, password, assoc=None):
         # encrypt password, ignore associated data
-        from Crypto.Random import get_random_bytes
+        from Cryptodome.Random import get_random_bytes
 
         salt = get_random_bytes(self.block_size)
-        from Crypto.Cipher import AES
+        from Cryptodome.Cipher import AES
 
         IV = get_random_bytes(AES.block_size)
         cipher = self._create_cipher(self.keyring_key, salt, IV)

--- a/keyrings/alt/tests/test_crypto.py
+++ b/keyrings/alt/tests/test_crypto.py
@@ -10,15 +10,15 @@ from keyrings.alt import file
 
 def is_crypto_supported():
     try:
-        __import__('Crypto.Cipher.AES')
-        __import__('Crypto.Protocol.KDF')
-        __import__('Crypto.Random')
+        __import__('Cryptodome.Cipher.AES')
+        __import__('Cryptodome.Protocol.KDF')
+        __import__('Cryptodome.Random')
     except ImportError:
         return False
     return True
 
 
-@pytest.mark.skipif(not is_crypto_supported(), reason="Need Crypto module")
+@pytest.mark.skipif(not is_crypto_supported(), reason="Need pycryptodomex module")
 class TestCryptedFileKeyring(FileKeyringTests):
     @pytest.fixture(autouse=True)
     def mocked_getpass(self, monkeypatch):

--- a/keyrings/alt/tests/test_file.py
+++ b/keyrings/alt/tests/test_file.py
@@ -157,7 +157,7 @@ class FileKeyringTests(BackendBasicTests):
 class TestEncryptedFileKeyring(FileKeyringTests):
     @pytest.fixture(autouse=True)
     def crypt_fixture(self, monkeypatch):
-        pytest.importorskip('Crypto')
+        pytest.importorskip('Cryptodome')
         fake_getpass = mock.Mock(return_value='abcdef')
         monkeypatch.setattr(getpass, 'getpass', fake_getpass)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ testing =
 	keyring >= 20
 
 	fs>=0.5,<2
-	pycryptodome
+	pycryptodomex
 
 	# gdata doesn't currently install on Python 3
 	# http://code.google.com/p/gdata-python-client/issues/detail?id=229


### PR DESCRIPTION
**pycryptodomex** is a module built from the same source code as **pycryptodome**, but it does not pretend to be old PyCrypto and uses its own module name instead (`Cryptodome`):

https://pypi.org/project/pycryptodomex/

We do not need compatibility with old PyCrypto, so we can use the new module name.

Debian (and I guess some other distributions) do not ship **pycryptodome** without **x** at all, so this change is needed for us to migrate away from old and unsecure PyCrypto:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=971312 