### PR TITLE
Fix tests exclusion from install

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,14 +15,14 @@ classifiers =
 
 [options]
 packages = find:
-include_package_data = true
 python_requires = >=3.6
 install_requires =
 setup_requires = setuptools_scm[toml] >= 3.4.1
 
 [options.packages.find]
 exclude =
-	tests
+	*.tests
+	*.tests.*
 
 [options.extras_require]
 testing =


### PR DESCRIPTION
`*.tests.*` is there just in case a subpackage below tests is introduced sometime.