### PR TITLE
Depend on jaraco.classes; fix #47

### DIFF
--- a/keyrings/alt/Gnome.py
+++ b/keyrings/alt/Gnome.py
@@ -6,9 +6,9 @@ try:
 except (ImportError, ValueError, AttributeError):
     pass
 
+from jaraco.classes import properties
 from keyring.backend import KeyringBackend
 from keyring.errors import PasswordSetError, PasswordDeleteError
-from keyring.util import properties
 
 
 class Keyring(KeyringBackend):
@@ -20,7 +20,7 @@ class Keyring(KeyringBackend):
     Use None for the default keyring.
     """
 
-    @properties.ClassProperty
+    @properties.classproperty
     @classmethod
     def priority(cls):
         if 'GnomeKeyring' not in globals():

--- a/keyrings/alt/Google.py
+++ b/keyrings/alt/Google.py
@@ -14,10 +14,10 @@ except ImportError:
     pass
 
 from . import keyczar
+from jaraco.classes import properties
 from keyring import errors
 from keyring import credentials
 from keyring.backend import KeyringBackend
-from keyring.util import properties
 from keyring.errors import ExceptionRaisedContext
 
 
@@ -70,7 +70,7 @@ class DocsKeyring(KeyringBackend):
         self._client.ssl = True
         self._login_reqd = True
 
-    @properties.ClassProperty
+    @properties.classproperty
     @classmethod
     def priority(cls):
         if not cls._has_gdata():

--- a/keyrings/alt/Windows.py
+++ b/keyrings/alt/Windows.py
@@ -2,7 +2,7 @@ import sys
 import base64
 import platform
 
-from keyring.util import properties
+from jaraco.classes import properties
 from keyring.backend import KeyringBackend
 from keyring.errors import PasswordDeleteError, ExceptionRaisedContext
 from . import file_base
@@ -36,7 +36,7 @@ class EncryptedKeyring(file_base.Keyring):
 
     version = "1.0"
 
-    @properties.ClassProperty
+    @properties.classproperty
     @classmethod
     def priority(self):
         """
@@ -64,7 +64,7 @@ class RegistryKeyring(KeyringBackend):
     the user's passwords and store them under registry keys
     """
 
-    @properties.ClassProperty
+    @properties.classproperty
     @classmethod
     def priority(self):
         """

--- a/keyrings/alt/file.py
+++ b/keyrings/alt/file.py
@@ -6,7 +6,7 @@ import json
 import getpass
 import configparser
 
-from keyring.util import properties
+from jaraco.classes import properties
 from .escape import escape as escape_for_ini
 
 from keyrings.alt.file_base import Keyring, decodebytes, encodebytes
@@ -70,7 +70,7 @@ class EncryptedKeyring(Encrypted, Keyring):
     filename = 'crypted_pass.cfg'
     pw_prefix = 'pw:'.encode()
 
-    @properties.ClassProperty
+    @properties.classproperty
     @classmethod
     def priority(self):
         "Applicable for all platforms, but not recommended."

--- a/keyrings/alt/file_base.py
+++ b/keyrings/alt/file_base.py
@@ -5,9 +5,10 @@ import abc
 import configparser
 from base64 import encodebytes, decodebytes
 
+from jaraco.classes import properties
 from keyring.errors import PasswordDeleteError
 from keyring.backend import KeyringBackend
-from keyring.util import platform_, properties
+from keyring.util import platform_
 from .escape import escape as escape_for_ini
 
 

--- a/keyrings/alt/multi.py
+++ b/keyrings/alt/multi.py
@@ -1,6 +1,6 @@
 import itertools
 
-from keyring.util import properties
+from jaraco.classes import properties
 from keyring.backend import KeyringBackend
 from keyring import errors
 
@@ -16,7 +16,7 @@ class MultipartKeyringWrapper(KeyringBackend):
         self._keyring = keyring
         self._max_password_size = max_password_size
 
-    @properties.ClassProperty
+    @properties.classproperty
     @classmethod
     def priority(cls):
         return 0

--- a/keyrings/alt/pyfs.py
+++ b/keyrings/alt/pyfs.py
@@ -2,9 +2,10 @@ import os
 import base64
 import configparser
 
+from jaraco.classes import properties
 from keyring import errors
 from .escape import escape as escape_for_ini
-from keyring.util import platform_, properties
+from keyring.util import platform_
 from keyring.backend import KeyringBackend, NullCrypter
 from . import keyczar
 
@@ -212,7 +213,7 @@ class BasicKeyring(KeyringBackend):
         self.config.write(config_file)
         config_file.close()
 
-    @properties.ClassProperty
+    @properties.classproperty
     @classmethod
     def priority(cls):
         if not has_pyfs():

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
 packages = find_namespace:
 include_package_data = true
 python_requires = >=3.7
-install_requires =
+install_requires = jaraco.classes
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Use `jaraco.classes.properties` instead of `keyring.util.properties`, which was removed in keyring 23.9.0.