### PR TITLE
keyrings/alt/pyfs.py does not support 'fs v2'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ testing =
 	backports.unittest_mock
 	keyring >= 20
 
-	fs>=0.5,<3
+	fs>=0.5,<2
 	pycryptodomex
 	pycryptodome
 


### PR DESCRIPTION
'fs v2' was introduced in 2016, and pyfs.py has never been compatible.

Mark the 'fs' requirement to exclude v2 until pyfs.py is rewritten to support it.

Fixes issue #49 (pyfs backend seems to be incompatible with fs-2.4.16)