### PR TITLE
Fix "encyption" typo

### DIFF
--- a/keyrings/alt/file.py
+++ b/keyrings/alt/file.py
@@ -18,7 +18,7 @@ class PlaintextKeyring(Keyring):
     "Applicable for all platforms, but not recommended"
 
     filename = 'keyring_pass.cfg'
-    scheme = 'no encyption'
+    scheme = 'no encryption'
     version = '1.0'
 
     def encrypt(self, password, assoc=None):


### PR DESCRIPTION
spotted in our output of [`datalad wtf`](https://github.com/datalad/datalad/issues/7733)